### PR TITLE
Changed the heading to something correct

### DIFF
--- a/math/proofs.md
+++ b/math/proofs.md
@@ -3,7 +3,7 @@ layout: page
 title: Proofs
 ---
 
-# Divisibility by primes
+# Prime numbers
 
 ## If n² is divisible by a prime p, then n is divisible by p
 


### PR DESCRIPTION
"Divisibility by primes" was not consistent with the content of the page.
